### PR TITLE
No comma in algo names allowed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Here `run_1` to `run_n` correspond to the number of independent runs in a given 
 >
 > Due to the underlying statistical aggregation relying on `numpy` array operations it is required that all data contain the same number of data points. This implies that, for a given environment, it is required that all experiment trials should be done using the same algorithms, on the same tasks, for the same number of independent runs and for the same amount of evaluation steps. The code will currently check that these conditions are met and will not be able to progress otherwise. In the case that this happens, the `check_data` method of the [`DiagnoseData`](marl_eval/utils/diagnose_data_errors.py) class will be able to tell a user exactly what is causing the issues in their raw experiment data.
 
+> 🚧 **Important note on algorithm names** 🚧
+>
+> For producing probability of improvement plots, it is important that any algorithm names in the dataset do not contain any commas.
+
 ### Metrics to be normalised during data processing ⚗️
 Certain metrics, like episode returns, are required to be normalised during data processing. In order to achieve this it is required that users give these metric names, in the form of strings in a python list, to the `data_process_pipeline` function, the `create_matrices_for_rliable` function and all plotting functions as an argument. In the case where no normalisation is required this argument may be omitted.
 

--- a/tests/data_processing_utils_test.py
+++ b/tests/data_processing_utils_test.py
@@ -34,6 +34,7 @@ from expected_test_data import (
 )
 
 from marl_eval.utils.data_processing_utils import (
+    check_comma_in_algo_names,
     create_matrices_for_rliable,
     data_process_pipeline,
     get_and_aggregate_data_single_task,
@@ -228,3 +229,38 @@ def test_single_task_data_aggregation(
         task_win_rate_ci_data,
         expected_single_task_ci_data_win_rates,
     )
+
+
+@pytest.mark.parametrize(
+    "algorithm_names, should_get_valid, names_valid, returned_names",
+    [
+        (["algo_1", "algo_2", "algo_3"], True, True, ["algo_1", "algo_2", "algo_3"]),
+        (["algo_1", "algo_2", "algo_3"], False, True, []),
+        (["algo,_1", "algo,_2", "algo_3"], True, False, ["algo_3"]),
+        (["algo,_1", "algo_2", "algo_3"], False, False, ["algo,_1"]),
+    ],
+)
+def test_check_comma_in_algo_names(
+    algorithm_names: list,
+    should_get_valid: bool,
+    names_valid: bool,
+    returned_names: list,
+) -> None:
+    """Tests that the check_comma_in_algo_names function works \
+    as expected.
+
+    Args:
+        algorithm_names: names of algorithms to be checked.
+        should_get_valid: whether valid names should be returned.
+        names_valid: whether algorithm names are valid.
+        returned_names: either the valid or invalid names as
+            returned by the function.
+    """
+
+    names_valid_output, names_output = check_comma_in_algo_names(
+        algos=algorithm_names,
+        get_valid=should_get_valid,
+    )
+
+    assert names_valid_output == names_valid
+    assert names_output == returned_names

--- a/tests/diagnose_data_errors_test.py
+++ b/tests/diagnose_data_errors_test.py
@@ -91,6 +91,7 @@ def test_valid_data(valid_raw_data: Dict[str, Dict[str, Any]]) -> None:
     check_data_results = data_diag_tools.check_data()["env_1"]
     assert check_data_results == {
         "valid_algorithms": True,
+        "valid_algorithm_names": True,
         "valid_runs": True,
         "valid_steps": True,
         "valid_metrics": True,
@@ -103,6 +104,7 @@ def test_invalid_algo_data(invalid_algo_raw_data: Dict[str, Dict[str, Any]]) -> 
     check_data_results = data_diag_tools.check_data()["env_1"]
     assert check_data_results == {
         "valid_algorithms": False,
+        "valid_algorithm_names": True,
         "valid_runs": True,
         "valid_steps": True,
         "valid_metrics": True,
@@ -115,6 +117,7 @@ def test_invalid_runs_data(invalid_runs_raw_data: Dict[str, Dict[str, Any]]) -> 
     check_data_results = data_diag_tools.check_data()["env_1"]
     assert check_data_results == {
         "valid_algorithms": True,
+        "valid_algorithm_names": True,
         "valid_runs": False,
         "valid_steps": True,
         "valid_metrics": True,
@@ -129,6 +132,7 @@ def test_invalid_metrics_data(
     check_data_results = data_diag_tools.check_data()["env_1"]
     assert check_data_results == {
         "valid_algorithms": True,
+        "valid_algorithm_names": True,
         "valid_runs": True,
         "valid_steps": True,
         "valid_metrics": False,
@@ -141,6 +145,7 @@ def test_invalid_data(invalid_raw_data: Dict[str, Dict[str, Any]]) -> None:
     check_data_results = data_diag_tools.check_data()["env_1"]
     assert check_data_results == {
         "valid_algorithms": False,
+        "valid_algorithm_names": True,
         "valid_runs": False,
         "valid_steps": False,
         "valid_metrics": False,


### PR DESCRIPTION
## What?
The way that algorithm pair names are joined for the `probability_of_improvement` plots will lead to errors if algorithm names contain commas. This PR checks whether any algorithm names in the dataset contain any commas and will raise an error if this is the case.  
## Why?
The enable the downstream use of all plotting tools. 
## How?
Added a check for algorithms. 
## Extra
Wrote a very simple unit test for the new feature. Updated current `DiagnoseData` tests as well. 
