### PR TITLE
Fix: Enhanced flexibility in `create_matrices_for_rliable` 

### DIFF
--- a/marl_eval/utils/data_processing_utils.py
+++ b/marl_eval/utils/data_processing_utils.py
@@ -419,9 +419,14 @@ def create_matrices_for_rliable(  # noqa: C901
             for algorithm in algorithms:
                 for i, run in enumerate(runs):
                     for j, task in enumerate(tasks):
-                        metric_dictionary[metric][algorithm][i][j] = data_env[task][
-                            algorithm
-                        ][run][absolute_metric_key][metric]
+                        # Get the metric data
+                        metric_data = data_env[task][algorithm][run][absolute_metric_key][metric]
+                        
+                        # Compute the mean if it's a list, otherwise use as is
+                        data = np.mean(metric_data) if isinstance(metric_data, list) else metric_data
+                        
+                        # Store the data in the metric dictionary
+                        metric_dictionary[metric][algorithm][i][j] = data
 
         metric_dictionary_return = metric_dictionary
 
@@ -451,9 +456,14 @@ def create_matrices_for_rliable(  # noqa: C901
                 for algorithm in algorithms:
                     for i, run in enumerate(runs):
                         for j, task in enumerate(tasks):
-                            metric_dictionary[metric][algorithm][i][j] = data_env[task][
-                                algorithm
-                            ][run][step][metric]
+                            # Get the metric data
+                            metric_data = data_env[task][algorithm][run][step][metric]
+                            
+                            # Compute the mean if it's a list, otherwise use as is
+                            data = np.mean(metric_data) if isinstance(metric_data, list) else metric_data
+                            
+                            # Store the data in the metric dictionary
+                            metric_dictionary[metric][algorithm][i][j] = data
 
             for metric in mean_absolute_metrics:
                 for algorithm in algorithms:

--- a/marl_eval/utils/data_processing_utils.py
+++ b/marl_eval/utils/data_processing_utils.py
@@ -420,11 +420,15 @@ def create_matrices_for_rliable(  # noqa: C901
                 for i, run in enumerate(runs):
                     for j, task in enumerate(tasks):
                         # Get the metric data
-                        metric_data = data_env[task][algorithm][run][absolute_metric_key][metric]
-                        
+                        metric_data = data_env[task][algorithm][run][
+                            absolute_metric_key
+                        ][metric]
                         # Compute the mean if it's a list, otherwise use as is
-                        data = np.mean(metric_data) if isinstance(metric_data, list) else metric_data
-                        
+                        data = (
+                            np.mean(metric_data)
+                            if isinstance(metric_data, list)
+                            else metric_data
+                        )
                         # Store the data in the metric dictionary
                         metric_dictionary[metric][algorithm][i][j] = data
 
@@ -458,10 +462,12 @@ def create_matrices_for_rliable(  # noqa: C901
                         for j, task in enumerate(tasks):
                             # Get the metric data
                             metric_data = data_env[task][algorithm][run][step][metric]
-                            
                             # Compute the mean if it's a list, otherwise use as is
-                            data = np.mean(metric_data) if isinstance(metric_data, list) else metric_data
-                            
+                            data = (
+                                np.mean(metric_data)
+                                if isinstance(metric_data, list)
+                                else metric_data
+                            )
                             # Store the data in the metric dictionary
                             metric_dictionary[metric][algorithm][i][j] = data
 


### PR DESCRIPTION
## What?
Updated the create_matrices_for_rliable function to handle metrics data in both float and list formats.
## Why?
This modification addresses an issue where supplying a JSON file containing the average of the metrics results in the data[env][task][...][metric] being interpreted as a list. This previously led to errors when incorporating these metrics into the `metric_dictionary_return`

