### PR TITLE
fix: use twine for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          pip install --upgrade pip hatch twine
+          pip install --upgrade pip setuptools twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          hatch build
+          python setup.py sdist
           twine upload dist/*


### PR DESCRIPTION
## What?
Use twine for pushing to PyPi instead of Hatch.
