### PR TITLE
Use github runners for ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10"]
-        os: [self-hosted]
+        os: [ubuntu-latest]
 
     steps:
     - name: Checkout marl_eval


### PR DESCRIPTION
## What?
Use Github runners instead of self hosted runners for the CI workflow. 